### PR TITLE
Fix bug in elimination function

### DIFF
--- a/source/kernel/matrix_addon.c
+++ b/source/kernel/matrix_addon.c
@@ -291,7 +291,7 @@ unsigned int mpolyhedron_eliminate_first_variables(Matrix *Eqs, Matrix *Ineqs) {
   for (i = 0; i < Eqs->NbRows; i++) {
     /* find j, the first (non-marked) row of Eqs with a non-zero coefficient */
     for (j = 0; j < Eqs->NbRows &&
-                (value_notzero_p(Eqs->p[j][i + 1]) || (!value_cmp_si(Eqs->p[j][0], 2)));
+                (value_zero_p(Eqs->p[j][i + 1]) || (!value_cmp_si(Eqs->p[j][0], 2)));
          j++)
       ;
     /* if no row is found in Eqs that allows to eliminate variable i, return an


### PR DESCRIPTION
We're looking for the first row with a nonzero coefficient, but we were incrementing our counter when we found one instead of stopping.

This was causing a segfault in the cohomcalg, which has polylib as a dependency.  See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1138749